### PR TITLE
TTFB calculation

### DIFF
--- a/files/en-us/glossary/time_to_first_byte/index.html
+++ b/files/en-us/glossary/time_to_first_byte/index.html
@@ -11,7 +11,7 @@ tags:
 
 <p>TTFB is the time it takes between the start of the request and the start of the response, in milliseconds:</p>
 
-<pre>TTFB = <a href="/en-US/docs/Web/API/PerformanceResourceTiming/responseStart">responseStart</a> - <a href="/en-US/docs/Web/API/PerformanceResourceTiming/requestStart">requestStart</a></pre>
+<pre>TTFB = <a href="/en-US/docs/Web/API/PerformanceResourceTiming/responseStart">responseStart</a></pre>
 
 <h2 id="See_also">See also</h2>
 


### PR DESCRIPTION
 I suggest "TTFB= responseStart - navigationStart" instead of "TTFB= responseStart - requestStart".

requestStart fires after domainLookupEnd, secureConnectionStart and connectEnd as defined by the Processing Model of the PerformanceResourceTiming interface (URL: https://www.w3.org/TR/resource-timing-1/#dom-performanceresourcetiming-requeststart ). As this page defines TTFB time as including "DNS lookup and establishing the connection using a TCP handshake and SSL handshake if the request is made over https."

By the way, Google calculates the TTFB in their Chrome Extension "web vitals" as  "getTTFB=responseStart"
****extract form URL: https://github.com/GoogleChrome/web-vitals/blob/master/src/getTTFB.ts***
export const getTTFB = (onReport: ReportHandler) => {
const metric = initMetric('TTFB');

afterLoad(() => {
try {
// Use the NavigationTiming L2 entry if available.
const navigationEntry = performance.getEntriesByType('navigation')[0] ||
getNavigationEntryFromPerformanceTiming();

  metric.value = metric.delta =
      (navigationEntry as PerformanceNavigationTiming).responseStart;

  metric.entries = [navigationEntry];

  onReport(metric);
} catch (error) {
  // Do nothing.
}
});
};
*****